### PR TITLE
Changed source Url in Gatsby-source-Wordpress

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -31,7 +31,7 @@ module.exports = {
     {
       resolve: "gatsby-source-wordpress",
       options: {
-        baseUrl: "localhost:8888/lasuvas_cms",  //"lasuvasmexico.com",
+        baseUrl: "lasuvasmexico.com", //"localhost:8888/lasuvas_cms", 
         protocol: "http",
         hostingWPCOM: false,
         useACF: true,
@@ -43,8 +43,8 @@ module.exports = {
         verboseOutput: false,
         perPage: 100,
         searchAndReplaceContentUrls: {
-          sourceUrl: "localhost:8888/lasuvas_cms",
-          replacementUrl: "localhost:8888/lasuvas_cms",
+          sourceUrl: "lasuvasmexico.com", //"localhost:8888/lasuvas_cms",
+          replacementUrl: "lasuvasmexico.com", //"localhost:8888/lasuvas_cms",
         },
         concurrentRequests: 10,
         includedRoutes: [


### PR DESCRIPTION
changed the baseUrl, sourceUrL and replacementUrl in gatsby-source-wordpress to point to lasuvasmexico.com instead of localhost.