### PR TITLE
added site url to gatsby-config.js

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -9,7 +9,7 @@ module.exports = {
     title: `Las Uvas`,
     description: `Specializing In Mexican Wine Tastings`,
     author: `@gatsbyjs`,
-    //siteUrl: 'http://lasuvasmexico.com'
+    siteUrl: 'http://lasuvasmexico.com'
   },
   plugins: [
     `gatsby-plugin-sass`,


### PR DESCRIPTION
For localhost developement commented out siteUrl field in gatsby-config. This is needed for production so uncommented. 