### PR TITLE
UPDATED GATSBY-BROWSER GATSBY-CONFIG AND PAKCAG.JSON 

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,11 +1,9 @@
 // Check that service workers are supported
-if ('serviceWorker' in navigator) {
+/* if ('serviceWorker' in navigator) {
     // Use the window load event to keep the page load performant
     window.addEventListener('load', () => {
       navigator.serviceWorker.register('/sw.js');
     });
   }
 
-export const registerServiceWorker = () => true 
-
-
+  export const registerServiceWorker = () => true */

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -77,7 +77,7 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-offline',
     options: {
-      precachePages: [ `/tastings/`, `/mission/`],
+      precachePages: ['/tastings/', '/mission/'],
       workboxConfig: {
         runtimeCaching: [{
           urlPattern: 'lasuvasmexico.com/',
@@ -104,19 +104,6 @@ module.exports = {
           cacheableResponse: {
             statuses: [0, 200],
           },
-          plugins: [
-            {cacheDidUpdate: () => {
-                const answer = window.confirm(
-                `This application has been updated. ` +
-                  `Reload to display the latest version?`
-                )
-            
-                if (answer === true) {
-                window.location.reload()
-                }
-              }
-            }
-          ],
         },
       }],
     },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "format": "prettier --write src/**/*.{js,jsx}",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\""
+    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\"",
+    "clean": "gatsby clean"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.22",


### PR DESCRIPTION
FOR SERVICE WORKER FIXES

Having issues with the service worker. Removed the cachesDidUpdate code from the gatsby-config.js as it belongs in the gatsby-browser.js. Will update when I get service worker working. Commented out service worker registration as it appears it does it under the hood as part of the gatsby-plugin-offline. Need to test in production. No way to test in localhost. added "gatsby-clean" to the package.json to clear the cache in development.